### PR TITLE
feat: add card info lookup via Scryfall

### DIFF
--- a/src/dealdex/__init__.py
+++ b/src/dealdex/__init__.py
@@ -1,5 +1,7 @@
 """Deal-Dex package."""
 
-__all__ = ["__version__"]
+from .cards import get_card_info
+
+__all__ = ["__version__", "get_card_info"]
 
 __version__ = "0.1.0"

--- a/src/dealdex/cards.py
+++ b/src/dealdex/cards.py
@@ -1,0 +1,38 @@
+"""Utilities for fetching card information from Scryfall."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+SCRYFALL_NAMED_URL = "https://api.scryfall.com/cards/named"
+
+
+def get_card_info(name: str) -> Dict[str, Any]:
+    """Return card information from Scryfall.
+
+    Parameters
+    ----------
+    name:
+        The exact name of the card to look up.
+
+    Returns
+    -------
+    dict
+        A dictionary containing basic card details useful for searching.
+
+    Raises
+    ------
+    httpx.HTTPStatusError
+        If the Scryfall API returns an error status.
+    """
+    response = httpx.get(SCRYFALL_NAMED_URL, params={"exact": name}, timeout=10.0)
+    response.raise_for_status()
+    data = response.json()
+    return {
+        "name": data.get("name"),
+        "set": data.get("set"),
+        "set_name": data.get("set_name"),
+        "collector_number": data.get("collector_number"),
+    }

--- a/tests/test_card_info.py
+++ b/tests/test_card_info.py
@@ -1,0 +1,18 @@
+"""Tests for card information utilities."""
+
+import pytest
+import httpx
+
+from dealdex import get_card_info
+
+
+def test_get_card_info_returns_expected_fields():
+    info = get_card_info("Black Lotus")
+    assert info["name"] == "Black Lotus"
+    assert info["set"]
+    assert info["collector_number"]
+
+
+def test_get_card_info_unknown_card():
+    with pytest.raises(httpx.HTTPStatusError):
+        get_card_info("This Card Does Not Exist")


### PR DESCRIPTION
## Summary
- expose new `get_card_info` helper
- retrieve basic card info from Scryfall
- test card lookups and error handling

## Testing
- `pre-commit run --files src/dealdex/cards.py src/dealdex/__init__.py tests/test_card_info.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac51b11c3c832a8b50067d5b92c762