### PR TITLE
Add Python-based environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deal-Dex
 
-**Deal-Dex** is a bot that watches for **Pokémon** and **Magic: The Gathering** card deals on **eBay** and **TCGplayer**.  
+**Deal-Dex** is a bot that watches for **Pokémon** and **Magic: The Gathering** card deals on **eBay** and **TCGplayer**.
 It scans listings, checks them against your rules, and pushes alerts to **Discord (via Apprise)**.
 
 ![CI](https://img.shields.io/github/actions/workflow/status/your-org/deal-dex/ci.yml)
@@ -28,9 +28,9 @@ It scans listings, checks them against your rules, and pushes alerts to **Discor
 └─────────────┘     └──────────────┘     └────────────┘     └─────────────┘
 ```
 
-1. Feeds pull listings from eBay & TCGplayer  
-2. Engine checks them against your rules (`rules.yml`)  
-3. Matching deals get pushed into **Discord**  
+1. Feeds pull listings from eBay & TCGplayer
+2. Engine checks them against your rules (`rules.yml`)
+3. Matching deals get pushed into **Discord**
 
 ---
 
@@ -53,9 +53,8 @@ It scans listings, checks them against your rules, and pushes alerts to **Discor
 ```bash
 git clone https://github.com/your-org/deal-dex.git
 cd deal-dex
-python -m venv .venv && source .venv/bin/activate
-pip install -U pip
-pip install -r requirements.txt
+python scripts/setup_env.py
+source .venv/bin/activate
 ```
 
 ### 2) Configure environment
@@ -170,4 +169,3 @@ jobs:
 ## 📜 License
 
 MIT © You & Contributors
-# Deal-Dex

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 sqlalchemy
 typer
 pytest
+pre-commit

--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -1,0 +1,26 @@
+"""Bootstrap a local Python virtual environment for development.
+
+This script creates a `.venv` directory using Python's built-in `venv`
+module and installs project dependencies listed in `requirements.txt`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+def main() -> None:
+    env_dir = Path(".venv")
+    if not env_dir.exists():
+        venv.create(env_dir, with_pip=True)
+    python = env_dir / ("Scripts" if sys.platform == "win32" else "bin") / "python"
+    subprocess.check_call(
+        [str(python), "-m", "pip", "install", "-r", "requirements.txt"]
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add setup_env.py to bootstrap a local virtual environment and install dependencies
- update Quick start docs to use the Python setup script
- include pre-commit in requirements for development tooling

## Testing
- `pre-commit run --files scripts/setup_env.py README.md requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac829b2750832ab5df3d55feeb66b7