### PR TITLE
feat: add FastAPI card info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deal-Dex
 
-**Deal-Dex** is a bot that watches for **Pokémon** and **Magic: The Gathering** card deals on **eBay** and **TCGplayer**.  
+**Deal-Dex** is a bot that watches for **Pokémon** and **Magic: The Gathering** card deals on **eBay** and **TCGplayer**.
 It scans listings, checks them against your rules, and pushes alerts to **Discord (via Apprise)**.
 
 ![CI](https://img.shields.io/github/actions/workflow/status/your-org/deal-dex/ci.yml)
@@ -28,9 +28,9 @@ It scans listings, checks them against your rules, and pushes alerts to **Discor
 └─────────────┘     └──────────────┘     └────────────┘     └─────────────┘
 ```
 
-1. Feeds pull listings from eBay & TCGplayer  
-2. Engine checks them against your rules (`rules.yml`)  
-3. Matching deals get pushed into **Discord**  
+1. Feeds pull listings from eBay & TCGplayer
+2. Engine checks them against your rules (`rules.yml`)
+3. Matching deals get pushed into **Discord**
 
 ---
 
@@ -112,6 +112,18 @@ watches:
 python -m dealdex scan --rules rules.yml
 ```
 
+### 5) Run the API server
+
+```bash
+uvicorn dealdex.api:app --reload
+```
+
+Query card info:
+
+```bash
+curl http://localhost:8000/cards/Black%20Lotus
+```
+
 ---
 
 ## 🔔 Alerts (Discord)
@@ -170,4 +182,3 @@ jobs:
 ## 📜 License
 
 MIT © You & Contributors
-# Deal-Dex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "pydantic>=2.6",
     "sqlalchemy>=2.0",
     "apprise>=1.7",
+    "fastapi>=0.111",
+    "uvicorn>=0.29",
 ]
 
 [project.scripts]

--- a/src/dealdex/api.py
+++ b/src/dealdex/api.py
@@ -1,0 +1,32 @@
+"""FastAPI application exposing card information endpoints."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import FastAPI, HTTPException
+
+from .cards import get_card_info
+
+app = FastAPI(title="Deal-Dex API")
+
+
+@app.get("/cards/{name}")
+def read_card(name: str) -> dict[str, str | None]:
+    """Fetch card information by name.
+
+    Parameters
+    ----------
+    name:
+        Exact card name to look up.
+
+    Returns
+    -------
+    dict
+        Basic card details from Scryfall.
+    """
+    try:
+        return get_card_info(name)
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network failure paths
+        raise HTTPException(
+            status_code=exc.response.status_code, detail="Card not found"
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,21 @@
+"""Tests for the FastAPI card information endpoint."""
+
+from fastapi.testclient import TestClient
+
+from dealdex.api import app
+
+client = TestClient(app)
+
+
+def test_api_get_card_info() -> None:
+    response = client.get("/cards/Black%20Lotus")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Black Lotus"
+    assert data["set"]
+    assert data["collector_number"]
+
+
+def test_api_unknown_card() -> None:
+    response = client.get("/cards/This%20Card%20Does%20Not%20Exist")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add FastAPI app to expose `/cards/{name}` endpoint
- document how to run the API server
- include tests for the new endpoint

## Testing
- `pre-commit run --files pyproject.toml src/dealdex/api.py tests/test_api.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac843fe854832abe1f574104546ae1